### PR TITLE
Fixes #11035: Add the possibility to enable/disable the plugin globally. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,69 @@
+#
+# make all will build datasources.rpkg. 
+# make demo will build a license limited version of the plugin
+#
+
 RUDDER_BRANCH = $(shell sed -ne '/^rudder-branch=/s/rudder-branch=//p' build.conf)
 PLUGIN_BRANCH = $(shell sed -ne '/^plugin-branch=/s/plugin-branch=//p' build.conf)
 VERSION = $(RUDDER_BRANCH)-$(PLUGIN_BRANCH)
-NAME = $(shell sed -ne '/^plugin-id=/s/plugin-id=//p' build.conf)
+FULL_NAME = $(shell sed -ne '/^plugin-id=/s/plugin-id=//p' build.conf)
+NAME = $(shell echo $(FULL_NAME) | sed -ne 's/rudder-plugin-//p')
 MAVEN_OPTS = --batch-mode -U
 
-all: $(NAME)-$(VERSION).rpkg
+## for demo
+# standard destination path for the license file is in module directory, "license.sign"
+TARGET_LICENSE_PATH = /opt/rudder/share/plugins/$(NAME)/
+# standard destination path for the key is at JAR root, name: license.pubkey
+TARGET_KEY_CLASSPATH = license.pubkey
+# SIGNED_LICENSE_PATH: path towards the license file to embed
+# PUBLIC_KEY_PATH: path towards the public key to embed
 
-$(NAME)-$(VERSION).rpkg: target/metadata files.txz scripts.txz
-	ar r $(NAME)-$(VERSION).rpkg target/metadata files.txz scripts.txz
+# build the default oss version of the package
+all: std-files $(FULL_NAME)-$(VERSION).rpkg
 
-target/metadata:
-	mvn $(MAVEN_OPTS) -Dcommit-id=$$(git rev-parse HEAD 2>/dev/null || true) properties:read-project-properties resources:copy-resources@copy-metadata
+# build a "demo" version of the plugin, limited by a license file and verified by a public key
+demo: demo-files $(FULL_NAME)-$(VERSION).rpkg
 
-files.txz: target/datasources.jar
-	mkdir -p datasources
-	mv target/datasources.jar datasources/
-	cp ./src/main/resources/datasources-schema.sql datasources/
-	tar cJ -f files.txz datasources
-
-target/datasources.jar:
-	mvn $(MAVEN_OPTS) package
-	mv target/datasources-*-plugin-with-own-dependencies.jar target/datasources.jar
+clean:
+	rm -f scripts.txz files.txz $(FULL_NAME)-$(VERSION).rpkg
+	rm -rf target $(NAME)
 
 scripts.txz:
 	tar cJ -C packaging -f scripts.txz postinst
 
-clean:
-	rm -f scripts.txz files.txz $(NAME)-$(VERSION).rpkg
-	rm -rf target datasources
+$(FULL_NAME)-$(VERSION).rpkg: 
+	ar r $(FULL_NAME)-$(VERSION).rpkg target/metadata files.txz scripts.txz
+
+target/metadata:
+	mvn $(MAVEN_OPTS) $(DEMO) -Dcommit-id=$$(git rev-parse HEAD 2>/dev/null || true) properties:read-project-properties resources:copy-resources@copy-metadata
+
+std-files: common-files std-jar files.txz
+
+demo-files: common-files check-demo demo-jar files.txz
+
+common-files: target/metadata scripts.txz
+
+check-demo: 
+	test -n "$(SIGNED_LICENSE_PATH)"  # $$SIGNED_LICENSE_PATH must be defined
+	test -n "$(PUBLIC_KEY_PATH)"      # $$PUBLIC_KEY_PATH must be defined
+	$(eval DEMO = 1) # OK, we are in demo build
+
+files.txz: 
+	mkdir -p $(NAME)
+	cp ./src/main/resources/datasources-schema.sql $(NAME)/
+ifdef DEMO
+    # embed license file since we are in demo limited build
+	cp $(SIGNED_LICENSE_FILE) $(NAME)/
+endif
+	tar cJ -f files.txz $(NAME)
+
+std-jar:
+	mvn $(MAVEN_OPTS) package
+	mv target/datasources-*-plugin-with-own-dependencies.jar target/$(NAME).jar
+
+demo-jar:
+	mvn $(MAVEN_OPTS) -Dlimited -Dplugin-resource-publickey=$(TARGET_KEY_CLASSPATH) -Dplugin-resource-license=$(TARGET_LICENSE_PATH) -Dplugin-declared-version=$(VERSION) package
+	mv target/datasources-*-plugin-with-own-dependencies.jar target/$(NAME).jar
+	cp $(PUBLIC_KEY_PATH) target/$(TARGET_KEY_CLASSPATH)
+	jar -uf target/$(NAME).jar -C target $(TARGET_KEY_CLASSPATH)
+

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,6 @@
       <version>${http4s-version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <repositories>
@@ -264,4 +263,92 @@
     </repository>
   </repositories>
 
+  <!-- I hate maven. 100 lines for a F**** if/then/else. -->
+
+  <!-- Internal profile: FOR INTERNAL USE ONLY - active if -Dlimited is *not* specified. -->
+  <profiles>
+  <profile>
+    <id>internal-default</id>
+    <activation>
+      <!-- Activation via *absence* of a system property to ensure mutual exclusivity
+           of this profile with internal-limited -->
+      <property><name>!limited</name></property>
+    </activation>
+    <build><plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${basedir}/src/main/scala-templates/default</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>    
+    </plugins></build>
+  </profile>
+  <!-- Internal profile: FOR INTERNAL USE ONLY - active if -Dlimited is *not* specified. -->
+  <profile>
+    <id>internal-limited</id>
+    <activation>
+      <!-- Activation via *presence* of a system property to ensure mutual exclusivity
+           of this profile with internal-default -->
+      <property><name>limited</name></property>
+    </activation>
+    <build><plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+                <configuration>              
+                  <sourceDirectory>${basedir}/src/main/scala-templates/limited</sourceDirectory>
+                  <outputDirectory>${project.build.directory}/generated</outputDirectory>
+                </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>    
+    </plugins></build>
+    <dependencies>
+      <dependency>
+        <groupId>com.normation.rudder</groupId>
+        <artifactId>rudder-license</artifactId>
+        <version>4.1.8-SNAPSHOT</version>
+      </dependency>
+    </dependencies>    
+  </profile>
+  </profiles>
 </project>

--- a/src/main/scala-templates/default/com/normation/plugins/datasources/EnablePluginImpl.scala
+++ b/src/main/scala-templates/default/com/normation/plugins/datasources/EnablePluginImpl.scala
@@ -1,0 +1,49 @@
+/*
+*************************************************************************************
+* Copyright 2017 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.plugins.datasources
+
+import bootstrap.rudder.plugin.CheckRudderPluginDatasourcesEnable
+/*
+ * The class will be loaded by ServiceLoader, it needs an empty constructor.
+ */
+
+final class CheckRudderPluginDatasourcesEnableImpl() extends CheckRudderPluginDatasourcesEnable {
+  val isEnabled = true
+  val enabledStatus = "enabled"
+}
+

--- a/src/main/scala-templates/limited/com/normation/plugins/datasources/EnablePluginImpl.scala
+++ b/src/main/scala-templates/limited/com/normation/plugins/datasources/EnablePluginImpl.scala
@@ -1,0 +1,99 @@
+/*
+*************************************************************************************
+* Copyright 2017 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.plugins.datasources
+
+import com.normation.license._
+import java.util.Formatter.DateTime
+import java.io.InputStreamReader
+import org.joda.time.DateTime
+import bootstrap.rudder.plugin.CheckRudderPluginDatasourcesEnable
+
+
+/*
+ * This template file will processed at build time to choose
+ * the correct immplementation to use for the interface.
+ * The default implementation is to always enable status.
+ *
+ * The class will be loaded by ServiceLoader, it needs an empty constructor.
+ */
+
+final class CheckRudderPluginDatasourcesEnableImpl() extends CheckRudderPluginDatasourcesEnable {
+  // here are processed variables
+  val CLASSPATH_KEYFILE = "${plugin-resource-publickey}"
+  val FS_SIGNED_LICENSE = "${plugin-resource-license}"
+  val VERSION           = "${plugin-declared-version}"
+
+  // for now, we only read license info at load, because it's time consuming
+  val maybeInfo = 
+    for {
+      unchecked <- LicenseReader.readLicense(FS_SIGNED_LICENSE)
+      publicKey <- {
+                     val key = this.getClass.getClassLoader.getResourceAsStream(CLASSPATH_KEYFILE)
+                     if(key == null) {
+                       Left(LicenseError.IO(s"The resources '${key}' was not found"))
+                     } else {
+                       RSAKeyManagement.readPKCS8PublicKey(new InputStreamReader(key), None) //don't give to much info about path
+                     }
+                   }
+      checked   <- LicenseChecker.checkSignature(unchecked, publicKey)
+      version   <- Version.from(VERSION) match {
+                     case None    => Left(LicenseError.Parsing(s"Version is not valid: '${VERSION}'."))
+                     case Some(v) => Right(v)
+                   }
+    } yield {
+      (checked, version)
+    }
+
+  maybeInfo.fold( error => DataSourceLogger.error(error) , ok =>  DataSourceLogger.warn("License signature is valid.") )
+    
+  def isEnabled = enabledStatus == "enabled"
+
+  def enabledStatus = {
+    (for {
+      info               <- maybeInfo
+      (license, version) = info
+      check              <- LicenseChecker.checkLicense(license, DateTime.now, version)
+    } yield {
+      check
+    }) match {
+      case Right(x) => "enabled"
+      case Left (y) => y.msg
+    }
+  }
+}
+

--- a/src/main/scala/bootstrap/rudder/plugin/DataSourcesConf.scala
+++ b/src/main/scala/bootstrap/rudder/plugin/DataSourcesConf.scala
@@ -38,32 +38,28 @@
 package bootstrap.rudder.plugin
 
 import bootstrap.liftweb.RudderConfig
-
 import com.normation.inventory.domain.NodeId
-import com.normation.plugins.datasources.DataSourceJdbcRepository
 import com.normation.plugins.datasources.DataSourceRepoImpl
 import com.normation.plugins.datasources.DataSourcesPluginDef
-import com.normation.plugins.datasources.HttpQueryDataSourceService
 import com.normation.plugins.datasources.api.DataSourceApi9
 import com.normation.plugins.datasources.api.DataSourceApiService
 import com.normation.rudder.services.policies.PromiseGenerationHooks
 import com.normation.rudder.services.servers.NewNodeManagerHooks
 import com.normation.rudder.web.rest.ApiVersion
-
 import org.joda.time.DateTime
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.context.{ ApplicationContext, ApplicationContextAware }
 import org.springframework.context.annotation.{ Bean, Configuration }
-
 import net.liftweb.common.Box
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import com.normation.rudder.batch.AutomaticStartDeployment
-import com.normation.eventlog.ModificationId
-
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.batch.AsyncDeploymentAgent
 import com.normation.plugins.datasources.UpdateCause
+import com.normation.plugins.datasources.DataSourceJdbcRepository
+import com.normation.plugins.datasources.HttpQueryDataSourceService
+import com.normation.plugins.datasources.CheckRudderPluginDatasourcesEnableImpl
 
 /*
  * An update hook which triggers a configuration generation if needed
@@ -82,7 +78,11 @@ class OnUpdatedNodeRegenerate(regenerate: AsyncDeploymentAgent) {
  */
 object DatasourcesConf {
 
+
   import bootstrap.liftweb.{ RudderConfig => Cfg }
+
+  // by build convention, we have only one of that on the classpath
+  lazy val pluginStatusService =  new CheckRudderPluginDatasourcesEnableImpl()
 
   lazy val regenerationHook = new OnUpdatedNodeRegenerate(RudderConfig.asyncDeploymentAgent)
 
@@ -96,6 +96,7 @@ object DatasourcesConf {
         , regenerationHook.hook _
       )
     , Cfg.stringUuidGenerator
+    , pluginStatusService
   )
 
   // add data source pre-deployment update hook

--- a/src/main/scala/bootstrap/rudder/plugin/EnablePlugin.scala
+++ b/src/main/scala/bootstrap/rudder/plugin/EnablePlugin.scala
@@ -1,0 +1,49 @@
+/*
+*************************************************************************************
+* Copyright 2017 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package bootstrap.rudder.plugin
+
+/**
+ * This file defined an entry point
+ */
+trait CheckRudderPluginDatasourcesEnable {
+
+  def isEnabled(): Boolean
+
+  def enabledStatus(): String //not a string actually
+
+}

--- a/src/main/scala/com/normation/plugins/datasources/Repository.scala
+++ b/src/main/scala/com/normation/plugins/datasources/Repository.scala
@@ -57,6 +57,7 @@ import org.joda.time.DateTime
 import scala.concurrent.duration._
 import scalaz.{ Failure => _ }
 import scalaz.Scalaz._
+import bootstrap.rudder.plugin.CheckRudderPluginDatasourcesEnable
 
 final case class PartialNodeUpdate(
     nodes        : Map[NodeId, NodeInfo] //the node to update
@@ -156,9 +157,10 @@ class MemoryDataSourceRepository extends DataSourceRepository {
  * in data base.
  */
 class DataSourceRepoImpl(
-    backend: DataSourceRepository
-  , fetch  : QueryDataSourceService
-  , uuidGen: StringUuidGenerator
+    backend     : DataSourceRepository
+  , fetch       : QueryDataSourceService
+  , uuidGen     : StringUuidGenerator
+  , pluginStatus: CheckRudderPluginDatasourcesEnable
 ) extends DataSourceRepository with DataSourceUpdateCallbacks {
 
   /*
@@ -220,6 +222,7 @@ class DataSourceRepoImpl(
     val dss = new DataSourceScheduler(
           source
         , global
+        , pluginStatus
         , () => ModificationId(uuidGen.newUuid)
         , (cause: UpdateCause) => fetch.queryAll(source, cause)
     )

--- a/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala
+++ b/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala
@@ -73,6 +73,7 @@ import org.specs2.runner.JUnitRunner
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Random
+import bootstrap.rudder.plugin.CheckRudderPluginDatasourcesEnable
 
 
 
@@ -293,6 +294,11 @@ class UpdateHttpDatasetTest extends Specification with BoxSpecMatcher with Logga
     val uuidGen = new StringUuidGeneratorImpl()
   }
 
+  object Enabled extends CheckRudderPluginDatasourcesEnable {
+    val isEnabled = true
+    val enabledStatus = "enabled"
+  }
+
 
   sequential
 
@@ -317,6 +323,7 @@ class UpdateHttpDatasetTest extends Specification with BoxSpecMatcher with Logga
       val dss = new DataSourceScheduler(
           datasource.copy(enabled = false)
         , testScheduler
+        , Enabled
         , () => ModificationId(MyDatasource.uuidGen.newUuid)
         , action
      )
@@ -339,6 +346,7 @@ class UpdateHttpDatasetTest extends Specification with BoxSpecMatcher with Logga
       val dss = new DataSourceScheduler(
           datasource.copy(runParam = datasource.runParam.copy(schedule = NoSchedule(1.second)))
         , testScheduler
+        , Enabled
         , () => ModificationId(MyDatasource.uuidGen.newUuid)
         , action
      )
@@ -366,6 +374,7 @@ class UpdateHttpDatasetTest extends Specification with BoxSpecMatcher with Logga
       val dss = new DataSourceScheduler(
           datasource
         , testScheduler
+        , Enabled
         , () => ModificationId(MyDatasource.uuidGen.newUuid)
         , action
      )


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11035

So, this is the basic check for plugin enable-ity. It is horrible. The part for limitation is actually pretty straighfoward, we just forbid data sources fetch to be triggered (with a log, because we are not animals!)
But the build & module init, gods... Maven fault, mainly. 
So logic is that we want to let the standard OSS build not be impacted by that, ie: "git clone; mvn compile" should just compile. 
For that, we need to let the build be able to choose what checker impl to use, and then we need to uncouple the check loading/init from what impl was chosen. For the first, that means maven profiles and adding sources to compile, and it's horrible. 
For the second, it's basically what IoC provides, but no way I will use spring anymore (and it won't be serious to have a second IoC framework in one little plugin), so I went with the convention that the build is doing the right thing(tm), and we actually have the same package/class name for both implementation and only one is compiled into the jar. 
That also make it easier to use the correct impl for sure for a given jar: there is no choice past build. 

Not to merge until depencies project are settled, but give an overview of what is done. 